### PR TITLE
Deadlines calendar

### DIFF
--- a/GoogleCalendar.py
+++ b/GoogleCalendar.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 import logging
 import os.path
 import json
-# import uuid
 import sys
 
 # Third part libraries

--- a/GoogleCalendar.py
+++ b/GoogleCalendar.py
@@ -230,7 +230,7 @@ def create_event(service,
         elif error.resp.status == 404:
              logging.error(f"Error 404: Calendar with ID '{calendar_id}' not found.")
         elif error.resp.status == 400:
-             logging.error(f"Error 400: Bad Request. Check the structure of your event_body:\n{json.dumps(event_data, indent=2)}")
+             logging.error(f"Error 400: Bad Request. Check the structure of your event_body:\n{json.dumps(event_body, indent=2)}")
         return None
     except Exception as e:
         logging.error(f'An unexpected error occurred during event creation: {e}')

--- a/GoogleCalendar.py
+++ b/GoogleCalendar.py
@@ -206,13 +206,16 @@ def create_event(service,
 
     try:
         logging.debug(f"\nCreating event on calendar: {calendar_id}")
+        
         created_event = service.events().insert(
             calendarId=calendar_id,
             body=event_body,
             sendUpdates='none' # sendUpdates='none' means no notifications sent to attendees
         ).execute()
 
-        logging.info(f"""\n\n{' EVENT CREATED ':-^54}
+        heading: str = " ALL DAY EVENT CREATED " if all_day == True else " EVENT CREATED "
+
+        logging.info(f"""\n\n{heading:-^54}
 \tSummary: {created_event.get('summary')}
 \tGoogle Calendar ID: {created_event.get('id')}
 \tStatus: {created_event.get('status')}
@@ -298,6 +301,7 @@ def update_event(service,
     try:
         logging.debug(f"\nUpdating event {event_id} on calendar: {calendar_id}")
         # Using patch for partial updates
+        
         updated_event = service.events().patch(
             calendarId=calendar_id,
             eventId=event_id,
@@ -305,7 +309,8 @@ def update_event(service,
             sendUpdates='none' # sendUpdates='none' means no notifications sent to attendees
         ).execute()
 
-        logging.info(f"""\n\n{' EVENT UPDATED ':-^54}
+        heading: str = " ALL DAY EVENT UPDATED " if all_day == True else " EVENT UPDATED "
+        logging.info(f"""\n\n{heading:-^54}
 \tSummary: {updated_event.get('summary')}
 \tGoogle Calendar ID: {updated_event.get('id')}
 \tStatus: {updated_event.get('status')}
@@ -333,7 +338,8 @@ def update_event(service,
 
 def delete_event(service,
                  calendar_id: str,
-                 event_id: str
+                 event_id: str, 
+                 all_day: bool = False
                  ) -> bool:
     """
     Deletes an existing event from the specified calendar.
@@ -355,14 +361,15 @@ def delete_event(service,
         return False
 
     try:
-        logging.debug(f"\nAttempting to delete event {event_id} from calendar: {calendar_id}")
+        logging.debug(f"\nAttempting to delete event {event_id} from calendar: {calendar_id}")        
         service.events().delete(
             calendarId=calendar_id,
             eventId=event_id,
             sendUpdates='none' # sendUpdates='none' means no notifications sent to attendees
         ).execute()
 
-        logging.info(f"""\n\n{' EVENT DELETED ':-^54}
+        heading: str = " ALL DAY EVENT DELETED " if all_day == True else " EVENT DELETED "
+        logging.info(f"""\n\n{heading:-^54}
 \tEvent ID: {event_id}
 {'-' * 54}\n""")
         

--- a/StateController.py
+++ b/StateController.py
@@ -109,7 +109,46 @@ class State:
 
 
     def list_updated_deadlines(self, updated_deadlines: list[dict]) -> list[dict]:
-        ...
+        updated_deadlines_list: list[dict] = []
+
+        for deadline in updated_deadlines:
+            # First check to see if the task is in current_tasks already. 
+            state_deadline = [i for i in self.current_deadlines if i['uuid'] == deadline['uuid']]
+            if not state_deadline:
+                # If a task is totally new, then it's ID won't be in self.current_tasks yet and we can skip it.
+                pass 
+            elif deadline == state_deadline[0]:
+                # If the state_task and updated task are the same then we don't need to update anything
+                pass
+            elif not state_deadline[0].get('deadline'):
+                # No need to update the calendar if there is no deadline. 
+                pass
+            elif not deadline.get('deadline'):
+                # If the deadline has been deleted from the task then we skip it here. 
+                pass
+            elif deadline.get('status') == 'completed':
+                # If the task is already completed we can pass on updating it. 
+                pass
+
+            else:
+                # Only update this event if one of these fields specifically has changed 
+                state_deadline = state_deadline[0]
+                state_task_values = {'title': state_deadline.get('title'),
+                                     'uuid': state_deadline.get('uuid'),
+                                     'deadline': state_deadline.get('deadline')}
+                
+                updated_task_values = {'title': deadline.get('title'),
+                                       'uuid': deadline.get('uuid'),
+                                       'deadline': deadline.get('deadline')}
+                
+                if state_task_values != updated_task_values:
+                    logging.debug(f"UPDATED DEADLINE FOUND: {deadline.get('uuid')} | {deadline.get('title')}")
+                    deadline.update({'change_type': 'update_deadline'})
+                    updated_deadlines_list.append(deadline)
+                else:
+                    logging.debug(f"No updated deadlines found")
+
+        return updated_deadlines_list
 
 
     def list_completed_deadlines(self, updated_deadlines: list[dict]) -> list[dict]:

--- a/StateController.py
+++ b/StateController.py
@@ -100,10 +100,12 @@ class State:
     def list_new_deadlines(self, updated_deadlines: list[dict]) -> list[dict]:
         new_deadlines: list = [dl for dl in updated_deadlines if dl not in self.current_deadlines]
         if not new_deadlines:
+            logging.debug("No new Deadlines detected")
             pass
         else:
             for dl in new_deadlines:
                 dl.update({'change_type': 'new_deadline'})
+            logging.debug(f"New deadlines detected\n {new_deadlines}")
         
         return new_deadlines 
 

--- a/StateController.py
+++ b/StateController.py
@@ -20,7 +20,8 @@ class State:
         """Returns True if changes are found in Things app"""
             
         updated_tasks = things.today() + things.upcoming() + things.completed(last=config.COMPLETED_SCOPE)
-        if updated_tasks == self.current_tasks:
+        updated_deadlines = things.deadlines()
+        if updated_tasks == self.current_tasks and updated_deadlines == self.current_deadlines:
             return False 
         else:
             logging.debug("State Update Found")

--- a/StateController.py
+++ b/StateController.py
@@ -149,7 +149,3 @@ class State:
                     logging.debug(f"No updated deadlines found")
 
         return updated_deadlines_list
-
-
-    def list_completed_deadlines(self, updated_deadlines: list[dict]) -> list[dict]:
-        updated_deadlines: list[dict] = ...

--- a/StateController.py
+++ b/StateController.py
@@ -6,7 +6,8 @@ import config
 
 class State:
     def __init__(self):
-        self.current_tasks = list()
+        self.current_tasks: list[dict] = list()
+        self.current_deadlines: list[dict] = list()
 
 
     def list_tasks_in_scope() -> list[int]:
@@ -84,3 +85,23 @@ class State:
                     logging.debug(f"No updated tasks found")
 
         return updated_tasks_list
+
+
+
+    def list_new_deadlines(self, updated_deadlines: list[dict]) -> list[dict]:
+        new_deadlines: list = [dl for dl in updated_deadlines if dl not in self.current_deadlines]
+        if not new_deadlines:
+            pass
+        else:
+            for dl in new_deadlines:
+                dl.update({'change_type': 'new_deadline'})
+        
+        return new_deadlines 
+
+
+    def list_updated_deadlines(self, updated_deadlines: list[dict]) -> list[dict]:
+        ...
+
+
+    def list_completed_deadlines(self, updated_deadlines: list[dict]) -> list[dict]:
+        updated_deadlines: list[dict] = ...

--- a/StateController.py
+++ b/StateController.py
@@ -16,17 +16,25 @@ class State:
                     + things.completed(last=config.COMPLETED_SCOPE))
 
 
-    def detect_state_updates(self) -> bool:
+    def detect_task_updates(self) -> bool:
         """Returns True if changes are found in Things app"""
-            
         updated_tasks = things.today() + things.upcoming() + things.completed(last=config.COMPLETED_SCOPE)
-        updated_deadlines = things.deadlines()
-        if updated_tasks == self.current_tasks and updated_deadlines == self.current_deadlines:
+
+        if updated_tasks == self.current_tasks:
             return False 
         else:
-            logging.debug("State Update Found")
+            logging.debug("TASK UPDATE FOUND")
             return True
         
+
+    def detect_deadline_updates(self) -> bool:
+        updated_deadlines = things.deadlines()
+        
+        if updated_deadlines == self.current_deadlines:
+            return False
+        else:
+            logging.debug("DEADLINE UPDATE FOUND")
+            return True
 
 
     def list_new_tasks(self, updated_tasks: list[dict]) -> bool:

--- a/SyncController.py
+++ b/SyncController.py
@@ -49,11 +49,13 @@ def add_new_tasks_to_calendar(new_tasks: list[dict], calendar_events: list[dict]
 
 
 def update_tasks_on_calendar(updates: list[dict], updated_events: list[dict]) -> None:
-    task_updates: list = []
+    task_updates: list[dict] = []
 
     if not updated_events:
-        logging.warning("No upcoming task events returned by Google Calendar")
-        return
+        logging.warning("No upcoming task events returned by Google Calendar. Adding updated tasks to calendar as NEW")
+        for e in updates:
+            e['change_type'] = 'new'
+        return task_updates
 
     update_ids: list[str] = [task['uuid'] for task in updates]
 
@@ -72,9 +74,9 @@ def update_tasks_on_calendar(updates: list[dict], updated_events: list[dict]) ->
 
 
 def remove_completed_tasks(updated_tasks: list[dict], updated_events: list) -> list[dict]:
-        completed_tasks = []
+        completed_tasks: list[dict] = []
         
-        completed_task_ids: list = [task.get('uuid') for task in updated_tasks if task.get('status') == 'completed']
+        completed_task_ids: list[str] = [task.get('uuid') for task in updated_tasks if task.get('status') == 'completed']
         
         completed_calendar_event_ids: dict = {event.get('description'): event.get('id') for event in updated_events if event.get('description') in completed_task_ids}
 
@@ -107,12 +109,14 @@ def add_new_deadline_to_calendar(new_deadlines: list[dict], calendar_events: lis
 
 
 
-def update_deadlines_on_calendar(updated_deadlines: list[dict], updated_deadline_events: list[dict]) -> None:
+def update_deadlines_on_calendar(updated_deadlines: list[dict], updated_deadline_events: list[dict]) -> list[dict]:
     deadline_updates: list[dict] = []
 
     if not updated_deadline_events:
-        logging.warning("No upcoming deadlines returned by Google Calendar")
-        return
+        logging.warning("No upcoming deadlines returned by Google Calendar. Adding updated deadlines as NEW")
+        for dl in updated_deadlines:
+            dl['change_type'] = 'new_deadline'
+        return deadline_updates
     
     update_ids: list[str] = [dl['uuid'] for dl in updated_deadlines]
 

--- a/SyncController.py
+++ b/SyncController.py
@@ -121,6 +121,28 @@ def sync_calendar_changes(service: object, list_of_changes: list[dict]) -> None:
                                   calendar_id = config.THINGS_CALENDAR_ID,
                                   event_id = task.get('calendar_event_id'))
                 
+            case 'new_deadline': 
+                GCal.create_event(service = service,
+                                  calendar_id = config.DEADLINES_CALENDAR_ID,
+                                  event_name = task.get('title'),
+                                  task_uuid = task.get('uuid'),
+                                  event_date = task.get('start_date'),
+                                  all_day=True)
+                
+            case 'update_deadline': 
+                GCal.update_event(service = service,
+                                  calendar_id = config.DEADLINES_CALENDAR_ID,
+                                  event_id = task.get('calendar_event_id'),
+                                  event_name = task.get('title'),
+                                  task_uuid = task.get('uuid'),
+                                  event_date = task.get('start_date'),
+                                  all_day=True)
+                
+            case 'delete_deadline':
+                GCal.delete_event(service = service,
+                                  calendar_id = config.DEADLINES_CALENDAR_ID,
+                                  event_id = task.get('calendar_event_id'))
+                
     for task in list_of_changes: 
         push_change(task)
     

--- a/SyncController.py
+++ b/SyncController.py
@@ -31,10 +31,10 @@ def parse_duration_tag(task_object: str) -> int:
 
 
 
-def add_new_tasks_to_calendar(new_tasks: list[dict], calendar_events: list[dict]) -> None:
-    confirmed_tasks = []
+def add_new_tasks_to_calendar(new_tasks: list[dict], calendar_events: list[dict]) -> list[dict]:
+    confirmed_tasks: list[dict] = []
     
-    calendar_task_uuids = [event.get('description') for event in calendar_events]
+    calendar_task_uuids: list[str] = [event.get('description') for event in calendar_events]
     
     # Compare current tasks and calendar events to find only those tasks that are not yet on the calendar
     new_tasks = [task for task in new_tasks if task['uuid'] not in calendar_task_uuids] 
@@ -88,6 +88,21 @@ def remove_completed_tasks(updated_tasks: list[dict], updated_events: list) -> l
 
         return completed_tasks
                     
+
+def add_new_deadline_to_calendar(new_deadlines: list[dict], calendar_events: list[dict]) -> list[dict]:
+    confirmed_deadlines: list[dict] = []
+
+    calendar_deadline_uuids: list[str] = [event.get('description') for event in calendar_events]
+
+    # Compare current deadlines and calendar events to find only those tasks that are not yet on the calendar
+    new_deadlines: list = [dl for dl in new_deadlines if dl['uuid'] not in calendar_deadline_uuids]
+
+    if new_deadlines:
+        for deadline in new_deadlines:
+            deadline['change_type'] = 'new_deadline'
+            confirmed_deadlines.append(deadline)
+    
+    return confirmed_deadlines
 
 
 def sync_calendar_changes(service: object, list_of_changes: list[dict]) -> None:

--- a/SyncController.py
+++ b/SyncController.py
@@ -89,6 +89,7 @@ def remove_completed_tasks(updated_tasks: list[dict], updated_events: list) -> l
         return completed_tasks
                     
 
+
 def add_new_deadline_to_calendar(new_deadlines: list[dict], calendar_events: list[dict]) -> list[dict]:
     confirmed_deadlines: list[dict] = []
 
@@ -128,6 +129,20 @@ def update_deadlines_on_calendar(updated_deadlines: list[dict], updated_deadline
         return deadline_updates
 
 
+
+def remove_completed_deadlines(updated_deadlines: list[dict], updated_deadline_events: list) -> list[dict]:
+        removed_deadlines = []
+        
+        completed_deadline_ids: list[str] = [dl.get('uuid') for dl in updated_deadlines]
+
+        removed_calendar_event_ids: list[str] = [event.get('id') for event in updated_deadline_events if event.get('description') not in completed_deadline_ids]
+
+        for dl in removed_calendar_event_ids:
+            removed_deadlines.append({'change_type': 'delete_deadline', 
+                                      'calendar_event_id': dl
+                                      })
+
+        return removed_deadlines
 
 
 def sync_calendar_changes(service: object, list_of_changes: list[dict]) -> None:

--- a/SyncController.py
+++ b/SyncController.py
@@ -140,7 +140,7 @@ def sync_calendar_changes(service: object, list_of_changes: list[dict]) -> None:
                                   calendar_id = config.DEADLINES_CALENDAR_ID,
                                   event_name = task.get('title'),
                                   task_uuid = task.get('uuid'),
-                                  event_date = task.get('start_date'),
+                                  event_date = task.get('deadline'),
                                   all_day=True)
                 
             case 'update_deadline': 
@@ -149,7 +149,7 @@ def sync_calendar_changes(service: object, list_of_changes: list[dict]) -> None:
                                   event_id = task.get('calendar_event_id'),
                                   event_name = task.get('title'),
                                   task_uuid = task.get('uuid'),
-                                  event_date = task.get('start_date'),
+                                  event_date = task.get('deadline'),
                                   all_day=True)
                 
             case 'delete_deadline':

--- a/SyncController.py
+++ b/SyncController.py
@@ -52,7 +52,7 @@ def update_tasks_on_calendar(updates: list[dict], updated_events: list[dict]) ->
     task_updates: list = []
 
     if not updated_events:
-        logging.warning("No upcoming events returned by Google Calendar")
+        logging.warning("No upcoming task events returned by Google Calendar")
         return
 
     update_ids: list[str] = [task['uuid'] for task in updates]
@@ -103,6 +103,31 @@ def add_new_deadline_to_calendar(new_deadlines: list[dict], calendar_events: lis
             confirmed_deadlines.append(deadline)
     
     return confirmed_deadlines
+
+
+
+def update_deadlines_on_calendar(updated_deadlines: list[dict], updated_deadline_events: list[dict]) -> None:
+    deadline_updates: list[dict] = []
+
+    if not updated_deadline_events:
+        logging.warning("No upcoming deadlines returned by Google Calendar")
+        return
+    
+    update_ids: list[str] = [dl['uuid'] for dl in updated_deadlines]
+
+    deadline_uuid_event_id_pairs: dict = {event['description']: event['id'] for event in updated_deadline_events if event.get('description') in update_ids}
+
+    for deadline in updated_deadlines:
+        if not deadline_uuid_event_id_pairs.get(deadline['uuid']):
+            # This passes on attempting to update the calendar event if it has been deleted manually by user or is otherwise not on the calendar.
+            pass
+        else:
+            deadline.update({'calendar_event_id': deadline_uuid_event_id_pairs.get(deadline['uuid'])})
+            deadline_updates.append(deadline)
+
+        return deadline_updates
+
+
 
 
 def sync_calendar_changes(service: object, list_of_changes: list[dict]) -> None:

--- a/SyncController.py
+++ b/SyncController.py
@@ -49,7 +49,6 @@ def add_new_tasks_to_calendar(new_tasks: list[dict], calendar_events: list[dict]
 
 
 def update_tasks_on_calendar(updates: list[dict], updated_events: list[dict]) -> None:
-    
     task_updates: list = []
 
     if not updated_events:

--- a/SyncController.py
+++ b/SyncController.py
@@ -200,7 +200,8 @@ def sync_calendar_changes(service: object, list_of_changes: list[dict]) -> None:
             case 'delete_deadline':
                 GCal.delete_event(service = service,
                                   calendar_id = config.DEADLINES_CALENDAR_ID,
-                                  event_id = task.get('calendar_event_id'))
+                                  event_id = task.get('calendar_event_id'),
+                                  all_day=True)
                 
     for task in list_of_changes: 
         push_change(task)

--- a/ThingSync.py
+++ b/ThingSync.py
@@ -49,9 +49,14 @@ def main(state: State, service):
             if updated_deadlines := state.list_updated_deadlines(updated_deadlines):
                 deadline_changes.extend(Sync.update_deadlines_on_calendar(updated_deadlines, updated_deadline_events))
 
+            if config.ZEN_MODE == True:
+                completed_deadlines = Sync.remove_completed_deadlines(updated_deadlines, updated_deadline_events)
+                deadline_changes.extend(completed_deadlines)
+
             if deadline_changes:
                 Sync.sync_calendar_changes(service, deadline_changes)
 
+            
             state.current_deadlines = things.deadlines()
 
 

--- a/ThingSync.py
+++ b/ThingSync.py
@@ -46,6 +46,9 @@ def main(state: State, service):
             if new_deadlines := state.list_new_deadlines(updated_deadlines):
                 deadline_changes.extend(Sync.add_new_deadline_to_calendar(new_deadlines, updated_deadline_events))
 
+            if updated_deadlines := state.list_updated_deadlines(updated_deadlines):
+                deadline_changes.extend(Sync.update_deadlines_on_calendar(updated_deadlines, updated_deadline_events))
+
             if deadline_changes:
                 Sync.sync_calendar_changes(service, deadline_changes)
 

--- a/ThingSync.py
+++ b/ThingSync.py
@@ -4,6 +4,7 @@ This program will routinely check your tasks in Things and if they are not synce
 
 This program will also check on the times of existing task-events in Calendar and if the time of the event differs from the task, the task will be updated. 
 """
+from datetime import datetime
 import logging
 import time
 
@@ -64,6 +65,9 @@ def main(state: State, service):
 
 
 if __name__ == "__main__":
+    # Set the start time 
+    start: time = datetime.now()
+    
     # Set the logging level and format
     logs = logging.basicConfig(level=logging.DEBUG,
                                format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
@@ -81,9 +85,13 @@ if __name__ == "__main__":
     system.caffeinate()
 
     # Thead 1: Monitor Things db for changes to tasks
-    while True:
-        main(state, service)
-        time.sleep(1)
+    try:
+        while True:
+            main(state, service)
+            time.sleep(1)
+    except KeyboardInterrupt:
+        end: time = datetime.now()
+        logging.info(f"""\n\n\tThingSync stopped by KeyBoard Interupt\n\tRun time duration | {end - start}\n""")
    
     # Thread 2: Listen for change notifications from GCal 
 

--- a/ThingSync.py
+++ b/ThingSync.py
@@ -16,7 +16,7 @@ import config
 
 
 def main(state: State, service):
-    if state.detect_state_updates():
+    if state.detect_task_updates():
         updated_tasks = things.today() + things.upcoming() + things.completed(last=config.COMPLETED_SCOPE)
         updated_events = GCal.get_upcoming_events(service, calendar_id=config.THINGS_CALENDAR_ID).get('items')
 
@@ -37,7 +37,7 @@ def main(state: State, service):
 
         state.current_tasks = things.today() + things.upcoming() + things.completed(last=config.COMPLETED_SCOPE)
 
-        if config.DEADLINES_CALENDAR == True:
+        if state.detect_deadline_updates() and config.DEADLINES_CALENDAR == True:
             updated_deadlines = things.deadlines()
             updated_deadline_events = GCal.get_upcoming_events(service, calendar_id=config.DEADLINES_CALENDAR_ID).get('items')
             


### PR DESCRIPTION
This PR adds an entirely new feature called the Deadlines Calendar. The Deadlines calendar allows for Deadlines in Things to appear on a a separate calendar from your tasks. 

Since deadlines in Things have no time, only a date, they are always "all day" calendar events. Having these events appear on a separate calendar allows for fine tuning your calendar set up on a various applications such that you can give the calendar it's own color (I like red to match the Things application itself) as well as different alert and notification settings since an individual may want to treat deadlines differently in their workflow then they do with conventional tasks. 