### PR TITLE
Two way sync

### DIFF
--- a/GoogleCalendar.py
+++ b/GoogleCalendar.py
@@ -13,7 +13,9 @@ from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
 # Local Modules
+from StateController import State
 import config
+
 
 # --- Configuration ---
 # IMPORTANT: If modifying SCOPES, delete the file token.json.
@@ -114,7 +116,7 @@ def authenticate_google_calendar():
         return None
 
 
-def get_upcoming_events(service, calendar_id: str, max_results=1000, retry_count: int = 0) -> dict | None:
+def get_upcoming_events(service, calendar_id: str, state: State, max_results=1000, retry_count: int = 0) -> dict | None:
     """
     Fetches and prints the next 'max_results' events from the user's primary calendar.
 
@@ -127,7 +129,6 @@ def get_upcoming_events(service, calendar_id: str, max_results=1000, retry_count
         return
     
     try:
-        # today = datetime.today().date().isoformat() + 'T00:00:00Z'  # 'Z' indicates UTC time
         time_min = f"{datetime.today().date() - timedelta(days=config.COMPLETED_SCOPE_INT)}T00:00:00Z"  # 'Z' indicates UTC time
         events_result = service.events().list(
             calendarId=calendar_id,
@@ -136,6 +137,7 @@ def get_upcoming_events(service, calendar_id: str, max_results=1000, retry_count
             singleEvents=True,
             orderBy='startTime'
         ).execute()
+        state.most_recent_calendar_check = datetime.now()
         return events_result
 
     except HttpError as error:

--- a/StateController.py
+++ b/StateController.py
@@ -1,7 +1,6 @@
 # from datetime import datetime
 import things
 import logging
-import config
 
 
 class State:

--- a/StateController.py
+++ b/StateController.py
@@ -11,8 +11,6 @@ class State:
 
 
     def detect_task_updates(self, updated_tasks: list[dict]) -> bool:
-        # updated_tasks = things.today() + things.upcoming() + things.completed(last=config.COMPLETED_SCOPE)
-
         if updated_tasks == self.current_tasks:
             return False 
         else:

--- a/StateController.py
+++ b/StateController.py
@@ -10,9 +10,8 @@ class State:
         self.current_deadlines: list[dict] = list()
 
 
-    def detect_task_updates(self) -> bool:
-        """Returns True if changes are found in Things app"""
-        updated_tasks = things.today() + things.upcoming() + things.completed(last=config.COMPLETED_SCOPE)
+    def detect_task_updates(self, updated_tasks: list[dict]) -> bool:
+        # updated_tasks = things.today() + things.upcoming() + things.completed(last=config.COMPLETED_SCOPE)
 
         if updated_tasks == self.current_tasks:
             return False 

--- a/StateController.py
+++ b/StateController.py
@@ -1,4 +1,4 @@
-# from datetime import datetime
+from datetime import datetime
 import things
 import logging
 
@@ -8,6 +8,7 @@ class State:
         self.current_tasks: list[dict] = list()
         self.current_events: list[dict] = list()
         self.current_deadlines: list[dict] = list()
+        self.most_recent_calendar_check: datetime = datetime
 
 
     def detect_task_updates(self, updated_tasks: list[dict]) -> bool:

--- a/StateController.py
+++ b/StateController.py
@@ -6,6 +6,7 @@ import logging
 class State:
     def __init__(self):
         self.current_tasks: list[dict] = list()
+        self.current_events: list[dict] = list()
         self.current_deadlines: list[dict] = list()
 
 

--- a/SyncController.py
+++ b/SyncController.py
@@ -223,10 +223,9 @@ def add_new_tasks_to_Things(updated_events: list) -> list[dict]:
     new_task_event_filter: list[dict] = [event for event in updated_events if not is_valid_things_uuid(event.get('description'))]
 
     for event_task in new_task_event_filter:
-          event_task['change_type'] = 'delete'
-          event_task['make_task_type'] = 'new'
           event_task['calendar_event_id'] = event_task.get('id')
-        #   changes.append(event_task)
+          event_task['make_task_type'] = 'new'
+          event_task['change_type'] = 'delete'
           new_tasks.append(event_task)
 
     return new_tasks

--- a/SyncController.py
+++ b/SyncController.py
@@ -223,9 +223,9 @@ def add_new_tasks_to_Things(updated_events: list) -> list[dict]:
     new_task_event_filter: list[dict] = [event for event in updated_events if not is_valid_things_uuid(event.get('description'))]
 
     for event_task in new_task_event_filter:
-          event_task['calendar_event_id'] = event_task.get('id')
-          event_task['make_task_type'] = 'new'
-          event_task['change_type'] = 'delete'
+          event_task.update({'calendar_event_id': event_task.get('id'),
+                            'make_task_type': 'new',
+                            'change_type': 'delete'})
           new_tasks.append(event_task)
 
     return new_tasks

--- a/SyncController.py
+++ b/SyncController.py
@@ -217,7 +217,7 @@ def remove_completed_deadlines(updated_deadlines: list[dict], updated_deadline_e
 
 
 
-def add_new_tasks_to_Things(updated_events: list,  changes: list[dict]) -> list[dict]:
+def add_new_tasks_to_Things(updated_events: list) -> list[dict]:
     new_tasks: list[dict] = []
 
     new_task_event_filter: list[dict] = [event for event in updated_events if not is_valid_things_uuid(event.get('description'))]
@@ -225,7 +225,8 @@ def add_new_tasks_to_Things(updated_events: list,  changes: list[dict]) -> list[
     for event_task in new_task_event_filter:
           event_task['change_type'] = 'delete'
           event_task['make_task_type'] = 'new'
-          changes.append(event_task)
+          event_task['calendar_event_id'] = event_task.get('id')
+        #   changes.append(event_task)
           new_tasks.append(event_task)
 
     return new_tasks

--- a/SyncController.py
+++ b/SyncController.py
@@ -33,12 +33,25 @@ def parse_duration_tag(task_object: str) -> int:
         return int(valid_duration_tags[0][:-1])
 
 
+def make_duration_tag(calendar_object: dict) -> str:
+		start_datetime: datetime = datetime.fromisoformat(calendar_object.get('start')['dateTime'])
+		end_datetime: datetime = datetime.fromisoformat(calendar_object.get('end')['dateTime'])
+		delta: int = int((end_datetime - start_datetime).seconds / 60)
+		if delta % 60 != 0:
+			return f"{delta}m"
+		else:
+			return f"{int(delta / 60)}h"
+
+
 def is_valid_things_uuid(uuid: str) -> bool:
-	id_len: int = len(uuid)
-	if id_len == 21 or id_len == 22:
-		return True
-	else:
-		return False
+    if type(uuid) != str:
+        return False 
+     
+    id_len: int = len(uuid)
+    if id_len == 21 or id_len == 22:
+        return True
+    else:
+        return False
 
 
 def is_valid_task(task: dict) -> bool: 
@@ -79,7 +92,9 @@ def update_tasks_on_calendar(updated_events: list[dict]) -> list[dict]:
         for event in updated_events: 
                 things_task: dict = things.get(event.get('description'))
                 if not is_valid_task(things_task):
-                    logging.warning(f"WARNING: Event {event.get("id")} does not contain a valid Things ID.")
+                    logging.warning(f"""WARNING: 
+Event {event.get("id")} does not contain a valid Things ID. 
+Title: {event.get('summary')}""")
                     pass
                     # Occasionally, a things task might have a different ID or will disapear for various reasons and so we need to skip it here to avoid errors. 
                 else:
@@ -200,6 +215,34 @@ def remove_completed_deadlines(updated_deadlines: list[dict], updated_deadline_e
 
         return removed_deadlines
 
+
+
+def add_new_tasks_to_Things(updated_events: list,  changes: list[dict]) -> list[dict]:
+    new_tasks: list[dict] = []
+
+    new_task_event_filter: list[dict] = [event for event in updated_events if not is_valid_things_uuid(event.get('description'))]
+
+    for event_task in new_task_event_filter:
+          event_task['change_type'] = 'delete'
+          event_task['make_task_type'] = 'new'
+          changes.append(event_task)
+          new_tasks.append(event_task)
+
+    return new_tasks
+
+
+
+def sync_task_changes(list_of_changes: list[dict]):
+    for new_task in list_of_changes:
+        duration = make_duration_tag(new_task)
+        
+        match new_task.get('make_task_type'):
+             case 'new':
+                makeThings.make_new_task(title=new_task.get('summary'),
+                                         when=new_task.get('start')['dateTime'],
+                                         tags=[duration])
+
+         
 
 
 

--- a/SyncController.py
+++ b/SyncController.py
@@ -4,6 +4,7 @@ import things
 import makeThings
 import logging
 import config
+import time
 
 
 def parse_duration_tag(task_object: str) -> int:
@@ -33,7 +34,7 @@ def parse_duration_tag(task_object: str) -> int:
         return int(valid_duration_tags[0][:-1])
 
 
-def make_duration_tag(calendar_object: dict) -> str:
+def _make_duration_tag(calendar_object: dict) -> str:
 		start_datetime: datetime = datetime.fromisoformat(calendar_object.get('start')['dateTime'])
 		end_datetime: datetime = datetime.fromisoformat(calendar_object.get('end')['dateTime'])
 		delta: int = int((end_datetime - start_datetime).seconds / 60)
@@ -43,7 +44,19 @@ def make_duration_tag(calendar_object: dict) -> str:
 			return f"{int(delta / 60)}h"
 
 
-def is_valid_things_uuid(uuid: str) -> bool:
+def _replace_duration_tag(tags: list[str], duration_tag: str) -> list[str]:
+    if not tags:
+        tags.append(duration_tag)
+        return tags
+    else:
+        for tag in tags:
+            if tag[-1] in 'hm' and tag[:-1].isdigit():
+                tags.remove(tag)
+        tags.append(duration_tag)
+        return tags   
+
+
+def _is_valid_things_uuid(uuid: str) -> bool:
     if type(uuid) != str:
         return False 
      
@@ -54,10 +67,10 @@ def is_valid_things_uuid(uuid: str) -> bool:
         return False
 
 
-def is_valid_task(task: dict) -> bool: 
+def _is_valid_task(task: dict) -> bool: 
 	if type(task) != dict:
 		return False
-	elif is_valid_things_uuid(task.get('uuid')) == False:
+	elif _is_valid_things_uuid(task.get('uuid')) == False:
 		return False
 	else:
 		return True 
@@ -91,7 +104,7 @@ def update_tasks_on_calendar(updated_events: list[dict]) -> list[dict]:
         
         for event in updated_events: 
                 things_task: dict = things.get(event.get('description'))
-                if not is_valid_task(things_task):
+                if not _is_valid_task(things_task):
                     logging.warning(f"""WARNING: 
 Event {event.get("id")} does not contain a valid Things ID. 
 Title: {event.get('summary')}""")
@@ -220,7 +233,7 @@ def remove_completed_deadlines(updated_deadlines: list[dict], updated_deadline_e
 def add_new_tasks_to_Things(updated_events: list) -> list[dict]:
     new_tasks: list[dict] = []
 
-    new_task_event_filter: list[dict] = [event for event in updated_events if not is_valid_things_uuid(event.get('description'))]
+    new_task_event_filter: list[dict] = [event for event in updated_events if not _is_valid_things_uuid(event.get('description'))]
 
     for event_task in new_task_event_filter:
           event_task.update({'calendar_event_id': event_task.get('id'),
@@ -231,16 +244,51 @@ def add_new_tasks_to_Things(updated_events: list) -> list[dict]:
     return new_tasks
 
 
+def update_tasks_in_Things(state_events: list[dict], updated_events: list[dict]) -> list[dict]:
+    if state_events == updated_events:
+        return []
+    else:
+        changed_events = []
+        for event in state_events:
+            if _is_valid_things_uuid(event.get('description')):
+                matching_event = [updated_event for updated_event in updated_events if updated_event.get('id') == event.get('id')][0]
+                if event.get('updated') != matching_event.get('updated'):
+                    matching_event['make_task_type'] = 'update'
+                    changed_events.append(matching_event)
+
+        if changed_events:
+            logging.debug(f"update_tasks_in_Things() found updated events.")                
+            return changed_events
+
+
 
 def sync_task_changes(list_of_changes: list[dict]):
+    logging.debug(f"MAKING TASK CHANGES...\n{list_of_changes}")
     for new_task in list_of_changes:
-        duration = make_duration_tag(new_task)
-        
+        duration: str = _make_duration_tag(new_task)
         match new_task.get('make_task_type'):
-             case 'new':
+            case 'new':
                 makeThings.make_new_task(title=new_task.get('summary'),
                                          when=new_task.get('start')['dateTime'],
                                          tags=[duration])
+            
+            case 'update':
+                logging.debug(F":::CHANGING TASK:::\n{new_task}")
+                task_id: str = new_task.get('description')
+                
+                current_task_tags: list[str] | None = things.get(task_id).get('tags')
+                if not current_task_tags:
+                    updated_tags: list[str] = [duration]
+                else:
+                    updated_tags: list[str] = _replace_duration_tag(current_task_tags, duration)
+                
+                makeThings.update_task(auth_token=config.THINGS_AUTH_TOKEN,
+                                       task_id=task_id,
+                                       title=new_task.get('summary'),
+                                       when=new_task.get('start')['dateTime'],
+                                       tags=updated_tags)
+    # This sleep is needed to allow for Things to complete updating its database. 
+    time.sleep(1)
 
          
 
@@ -249,7 +297,7 @@ def sync_task_changes(list_of_changes: list[dict]):
 
 def sync_calendar_changes(service: object, list_of_changes: list[dict]) -> None:
     
-    def push_change(task: dict) -> None:
+    def _push_change(task: dict) -> None:
         duration = parse_duration_tag(task)
 
         match task.get('change_type'):
@@ -301,5 +349,5 @@ def sync_calendar_changes(service: object, list_of_changes: list[dict]) -> None:
                                   all_day=True)
                 
     for task in list_of_changes: 
-        push_change(task)
+        _push_change(task)
     

--- a/ThingSync.py
+++ b/ThingSync.py
@@ -33,7 +33,6 @@ def main(state: State, service, first_run: bool = False):
             #     task_changes.extend(updated_tasks)
 
             if task_changes:
-                logging.info(task_changes)
                 Sync.sync_calendar_changes(service, task_changes)
                 Sync.sync_task_changes(task_changes)
                 updated_tasks: list[dict] = things.today() + things.upcoming() + things.completed(last=config.COMPLETED_SCOPE)

--- a/ThingSync.py
+++ b/ThingSync.py
@@ -14,12 +14,16 @@ import time
 
 
 def main(state: State, service, first_run: bool = False):
-    if state.detect_task_updates() or first_run == True:
+    try:
+        updated_tasks: list[dict] = things.today() + things.upcoming() + things.completed(last=config.COMPLETED_SCOPE)
+    except:
+        logging.error(f"Main() function cannot run due to error gathering tasks")
+
+    if state.detect_task_updates(updated_tasks) or first_run == True:
         try:
-            updated_tasks: list[dict] = things.today() + things.upcoming() + things.completed(last=config.COMPLETED_SCOPE)
             updated_events: list[dict] = GCal.get_upcoming_events(service, calendar_id=config.THINGS_CALENDAR_ID).get('items')
         except:
-            logging.error(f"Main() function cannot continue due to missing tasks or calendar data")
+            logging.error(f"Main() function cannot continue due to error gathering calendar data")
             return
 
 

--- a/ThingSync.py
+++ b/ThingSync.py
@@ -22,7 +22,24 @@ def main(state: State, service, first_run: bool = False):
             logging.error(f"Main() function cannot continue due to missing tasks or calendar data")
             return
 
+        # List of changes to be made to calendar
         changes = []
+
+        if config.TWO_WAY_SYNC == True:
+            task_changes: list[dict] = []
+            
+            if new_tasks := Sync.add_new_tasks_to_Things(updated_events, changes):
+                task_changes.extend(new_tasks)
+
+            # if updated_tasks := Sync.update_tasks_in_Things(updated_tasks, updated_events):
+            #     task_changes.extend(updated_tasks)
+
+            if task_changes:
+                Sync.sync_calendar_changes(service, task_changes)
+                Sync.sync_task_changes(task_changes)
+                updated_tasks: list[dict] = things.today() + things.upcoming() + things.completed(last=config.COMPLETED_SCOPE)
+                updated_events: list[dict] = GCal.get_upcoming_events(service, calendar_id=config.THINGS_CALENDAR_ID).get('items')
+
         
         if new := Sync.add_new_tasks_to_calendar(updated_tasks, updated_events):
             changes.extend(new)

--- a/ThingSync.py
+++ b/ThingSync.py
@@ -22,24 +22,27 @@ def main(state: State, service, first_run: bool = False):
             logging.error(f"Main() function cannot continue due to missing tasks or calendar data")
             return
 
-        # List of changes to be made to calendar
-        changes = []
 
         if config.TWO_WAY_SYNC == True:
             task_changes: list[dict] = []
             
-            if new_tasks := Sync.add_new_tasks_to_Things(updated_events, changes):
+            if new_tasks := Sync.add_new_tasks_to_Things(updated_events):
                 task_changes.extend(new_tasks)
 
             # if updated_tasks := Sync.update_tasks_in_Things(updated_tasks, updated_events):
             #     task_changes.extend(updated_tasks)
 
             if task_changes:
+                logging.info(task_changes)
                 Sync.sync_calendar_changes(service, task_changes)
                 Sync.sync_task_changes(task_changes)
                 updated_tasks: list[dict] = things.today() + things.upcoming() + things.completed(last=config.COMPLETED_SCOPE)
                 updated_events: list[dict] = GCal.get_upcoming_events(service, calendar_id=config.THINGS_CALENDAR_ID).get('items')
 
+
+
+        # List of changes to be made to calendar
+        changes = []
         
         if new := Sync.add_new_tasks_to_calendar(updated_tasks, updated_events):
             changes.extend(new)

--- a/ThingSync.py
+++ b/ThingSync.py
@@ -23,6 +23,7 @@ def main(state: State, service, first_run: bool = False):
             return
 
 
+        # Detect and make changes to tasks from the calendar. 
         if config.TWO_WAY_SYNC == True:
             task_changes: list[dict] = []
             
@@ -39,8 +40,7 @@ def main(state: State, service, first_run: bool = False):
                 updated_events: list[dict] = GCal.get_upcoming_events(service, calendar_id=config.THINGS_CALENDAR_ID).get('items')
 
 
-
-        # List of changes to be made to calendar
+        # Detect and list task changes to be made to calendar
         changes = []
         
         if new := Sync.add_new_tasks_to_calendar(updated_tasks, updated_events):
@@ -59,6 +59,7 @@ def main(state: State, service, first_run: bool = False):
         state.current_tasks = things.today() + things.upcoming() + things.completed(last=config.COMPLETED_SCOPE)
 
 
+        # Detect and make changes to the Deadlines calendar. 
         if config.DEADLINES_CALENDAR == True and state.detect_deadline_updates():
             updated_deadlines: list[dict] = things.deadlines()
             updated_deadline_events: list[dict] = GCal.get_upcoming_events(service, calendar_id=config.DEADLINES_CALENDAR_ID).get('items')

--- a/ThingSync.py
+++ b/ThingSync.py
@@ -1,5 +1,6 @@
 from watchdog.observers import Observer
 
+# Local Modules
 from StateController import State
 import SyncController as Sync
 import GoogleCalendar as GCal
@@ -7,8 +8,10 @@ import things
 import system # import FileChangeHandler, caffeinate, things_database_file_path
 import config
 
-from datetime import datetime
+# Built In modules
 from logging.handlers import RotatingFileHandler
+from threading import Thread
+from datetime import datetime
 import logging
 import time
 
@@ -16,14 +19,14 @@ import time
 def main(state: State, service, first_run: bool = False):
     try:
         updated_tasks: list[dict] = things.today() + things.upcoming() + things.completed(last=config.COMPLETED_SCOPE)
-    except:
-        logging.error(f"Main() function cannot run due to error gathering tasks")
+    except Exception as e:
+        logging.error(f"Main() function cannot run due to error gathering tasks\n{e}")
 
     if state.detect_task_updates(updated_tasks) or first_run == True:
         try:
-            updated_events: list[dict] = GCal.get_upcoming_events(service, calendar_id=config.THINGS_CALENDAR_ID).get('items')
-        except:
-            logging.error(f"Main() function cannot continue due to error gathering calendar data")
+            updated_events: list[dict] = GCal.get_upcoming_events(service, state=state, calendar_id=config.THINGS_CALENDAR_ID).get('items')
+        except Exception as e:
+            logging.error(f"Main() function cannot continue due to error gathering calendar data\m{e}")
             return
 
         calendar_changes: bool = False
@@ -44,7 +47,7 @@ def main(state: State, service, first_run: bool = False):
                 Sync.sync_task_changes(task_changes)
                 calendar_changes = True
                 updated_tasks: list[dict] = things.today() + things.upcoming() + things.completed(last=config.COMPLETED_SCOPE)
-                updated_events: list[dict] = GCal.get_upcoming_events(service, calendar_id=config.THINGS_CALENDAR_ID).get('items')
+                updated_events: list[dict] = GCal.get_upcoming_events(service, state=state, calendar_id=config.THINGS_CALENDAR_ID).get('items')
 
 
         # Detect and list task changes to be made to calendar
@@ -70,7 +73,7 @@ def main(state: State, service, first_run: bool = False):
         # Detect and make changes to the Deadlines calendar. 
         if config.DEADLINES_CALENDAR == True and state.detect_deadline_updates():
             updated_deadlines: list[dict] = things.deadlines()
-            updated_deadline_events: list[dict] = GCal.get_upcoming_events(service, calendar_id=config.DEADLINES_CALENDAR_ID).get('items')
+            updated_deadline_events: list[dict] = GCal.get_upcoming_events(service, state=state, calendar_id=config.DEADLINES_CALENDAR_ID).get('items')
             
             deadline_changes: list[dict] = []
 
@@ -90,9 +93,24 @@ def main(state: State, service, first_run: bool = False):
             state.current_deadlines = things.deadlines()
         
         if calendar_changes:
-            state.current_events = GCal.get_upcoming_events(service, calendar_id=config.THINGS_CALENDAR_ID).get('items')
+            state.current_events = GCal.get_upcoming_events(service, state=state, calendar_id=config.THINGS_CALENDAR_ID).get('items')
 
 
+
+def check_for_calendar_changes(state: State, service, calendar_id: str) -> None:
+	while True:
+		delta = (datetime.now() - state.most_recent_calendar_check).seconds
+		if delta >= config.SYNC_INTERVAL:
+			logging.debug("Daemon checking for calendar changes...")
+			check: list[dict] = GCal.get_upcoming_events(service=service, state=state, calendar_id=calendar_id).get('items')
+			if check != state.current_events:
+				logging.debug("Calendar Updates Found...")
+				main(state=state, service=service, first_run=True)
+			else:
+				logging.debug("No Calendar updates found by calendar daemon")
+		else:
+			logging.debug("Daemon Sleeping...")
+		time.sleep(config.SYNC_INTERVAL)
 
 
 
@@ -128,7 +146,7 @@ if __name__ == "__main__":
     #Set the initial task state
     state = State()
     state.current_tasks = things.today() + things.upcoming() + things.completed(last=config.COMPLETED_SCOPE)
-    state.current_events = GCal.get_upcoming_events(service, calendar_id=config.THINGS_CALENDAR_ID).get('items')
+    state.current_events = GCal.get_upcoming_events(service, state=state, calendar_id=config.THINGS_CALENDAR_ID).get('items')
     state.current_deadlines = things.deadlines()
 
     # Subprocess to caffeinate the Mac while application is running to prevent sleep
@@ -139,6 +157,10 @@ if __name__ == "__main__":
     try:
         # Start by running the main update loop first to update calendars on start up.  
         main(state=state, service=service, first_run=True)
+        
+        calendar_daemon: Thread = Thread(target=check_for_calendar_changes, args=(state, service, config.THINGS_CALENDAR_ID))
+        calendar_daemon.start()
+
         # Now point to the Things DB for monitoring and run main() when changes are detected to the Things DB
         path = system.things_database_file_path()
         filename = 'Things Database.thingsdatabase/main.sqlite'   
@@ -147,6 +169,8 @@ if __name__ == "__main__":
         observer.schedule(event_handler, path=path, recursive=True)
         observer.start()
         observer.join()
+
+
     except KeyboardInterrupt:
         observer.stop()
         end: time = datetime.now()

--- a/ThingSync.py
+++ b/ThingSync.py
@@ -26,6 +26,7 @@ def main(state: State, service, first_run: bool = False):
             logging.error(f"Main() function cannot continue due to error gathering calendar data")
             return
 
+        calendar_changes: bool = False
 
         # Detect and make changes to tasks from the calendar. 
         if config.TWO_WAY_SYNC == True:
@@ -34,12 +35,14 @@ def main(state: State, service, first_run: bool = False):
             if new_tasks := Sync.add_new_tasks_to_Things(updated_events):
                 task_changes.extend(new_tasks)
 
-            # if updated_tasks := Sync.update_tasks_in_Things(updated_tasks, updated_events):
-            #     task_changes.extend(updated_tasks)
+            if detect_updated_tasks := Sync.update_tasks_in_Things(state.current_events, updated_events):
+                task_changes.extend(detect_updated_tasks)
 
             if task_changes:
+                logging.debug("TASK CHANGES FOUND.")
                 Sync.sync_calendar_changes(service, task_changes)
                 Sync.sync_task_changes(task_changes)
+                calendar_changes = True
                 updated_tasks: list[dict] = things.today() + things.upcoming() + things.completed(last=config.COMPLETED_SCOPE)
                 updated_events: list[dict] = GCal.get_upcoming_events(service, calendar_id=config.THINGS_CALENDAR_ID).get('items')
 
@@ -59,6 +62,7 @@ def main(state: State, service, first_run: bool = False):
                 
         if changes:
             Sync.sync_calendar_changes(service, changes)
+            calendar_changes = True
 
         state.current_tasks = things.today() + things.upcoming() + things.completed(last=config.COMPLETED_SCOPE)
 
@@ -81,8 +85,12 @@ def main(state: State, service, first_run: bool = False):
 
             if deadline_changes:
                 Sync.sync_calendar_changes(service, deadline_changes)
+                calendar_changes = True
 
             state.current_deadlines = things.deadlines()
+        
+        if calendar_changes:
+            state.current_events = GCal.get_upcoming_events(service, calendar_id=config.THINGS_CALENDAR_ID).get('items')
 
 
 
@@ -113,15 +121,15 @@ if __name__ == "__main__":
         logging.getLogger().addHandler(file_handler)
 
 
+    # Initiate the Google Calendar service/auth flow
+    service = GCal.authenticate_google_calendar()
 
     
     #Set the initial task state
     state = State()
     state.current_tasks = things.today() + things.upcoming() + things.completed(last=config.COMPLETED_SCOPE)
+    state.current_events = GCal.get_upcoming_events(service, calendar_id=config.THINGS_CALENDAR_ID).get('items')
     state.current_deadlines = things.deadlines()
-
-    # Initiate the Google Calendar service/auth flow
-    service = GCal.authenticate_google_calendar()
 
     # Subprocess to caffeinate the Mac while application is running to prevent sleep
     system.caffeinate()

--- a/ThingSync.py
+++ b/ThingSync.py
@@ -158,8 +158,9 @@ if __name__ == "__main__":
         # Start by running the main update loop first to update calendars on start up.  
         main(state=state, service=service, first_run=True)
         
-        calendar_daemon: Thread = Thread(target=check_for_calendar_changes, args=(state, service, config.THINGS_CALENDAR_ID))
-        calendar_daemon.start()
+        if config.TWO_WAY_SYNC:
+            calendar_daemon: Thread = Thread(target=check_for_calendar_changes, args=(state, service, config.THINGS_CALENDAR_ID))
+            calendar_daemon.start()
 
         # Now point to the Things DB for monitoring and run main() when changes are detected to the Things DB
         path = system.things_database_file_path()

--- a/config.py
+++ b/config.py
@@ -35,4 +35,4 @@ DATE_FMT: str = "%Y-%m-%d %H:%M:%S"
 
 # These are for turning 2-way sync on and off and setting the sync interval
 TWO_WAY_SYNC: bool = True
-SYNC_INTERVAL: int = 600
+SYNC_INTERVAL: int = 60

--- a/makeThings.py
+++ b/makeThings.py
@@ -83,7 +83,7 @@ def update_task(auth_token: str,
     
     parameters = [f"{k}={v}" for k, v in arguments.items() if v != Ellipsis]
     params = '&'.join(parameters)
-    base_url = "things:///update?"
+    base_url = "things:///update?reveal=False&"
     
     subprocess.run(['open', f"{base_url + params}"])
     

--- a/makeThings.py
+++ b/makeThings.py
@@ -35,7 +35,6 @@ def make_new_task(title: str = ...,
     base_url = "things:///add?reveal=False&"
     
     subprocess.run(['open', f"{base_url + params}"])
-    # print(f"{base_url + params}")
     
     heading: str = "NEW TASK CREATED BY MAKETHINGS"
     logging.info(f"{heading:-^54}\nTitle: {title}")

--- a/makeThings.py
+++ b/makeThings.py
@@ -37,7 +37,7 @@ def make_new_task(title: str = ...,
     subprocess.run(['open', f"{base_url + params}"])
     
     heading: str = "NEW TASK CREATED BY MAKETHINGS"
-    logging.info(f"{heading:-^54}\nTitle: {title}")
+    logging.info(f"\n{heading:-^54}\nTitle: {title}")
 
 
 def update_task(auth_token: str,
@@ -77,7 +77,7 @@ def update_task(auth_token: str,
         checklist = arguments.pop('checklist_items')    
         arguments['checklist-items'] = '\n'.join(checklist)
     
-    if checklist_items != Ellipsis:    
+    if tags != Ellipsis:    
         arguments['tags'] = ','.join(tags)    
     
     parameters = [f"{k}={v}" for k, v in arguments.items() if v != Ellipsis]
@@ -85,6 +85,9 @@ def update_task(auth_token: str,
     base_url = "things:///update?reveal=False&"
     
     subprocess.run(['open', f"{base_url + params}"])
+
+    heading: str = "TASK UPDATED BY MAKETHINGS"
+    logging.info(f"\n{heading:-^54}\nTitle: {title}")
     
 
 


### PR DESCRIPTION
This PR introduces full two-way sync to ThingSync.  Two-way sync allows for the user to make changes to calendar appointments like moving the time, duration, or changing the title, and having those changes be applied to the corresponding task in Things. 

This sync is powered by a new Thread in the application that polls Google Calendar at a set interval for changes. The default interval is currently every 60 seconds. 